### PR TITLE
Restore temporal resolution to 1ms

### DIFF
--- a/lib/rails_server_timings/controller_runtime.rb
+++ b/lib/rails_server_timings/controller_runtime.rb
@@ -8,11 +8,11 @@ module RailsServerTimings
 
         payload.each do |key, value|
           if idx = key.to_s =~ /_runtime/
-            timings << ("#{key[0, idx]}=%.1f" % (value.to_f/1000.0))
+            timings << ("#{key[0, idx]}=%.3f" % (value.to_f/1000.0))
           end
         end
 
-        timings << ("total=%.1f" % (event.duration.to_f/1000.0))
+        timings << ('total=%.3f' % (event.duration.to_f/1000.0))
 
         response.headers['Server-Timing'] = timings.join(', ')
       end


### PR DESCRIPTION
1d068f48c74264468cd079370dc99183ccc6ba38 correctly sets the unit for reported time to seconds, but missed out on setting the correct resolution for the generated value. This restores millisecond-level resolution.

Previous response:

![low_res](https://cloud.githubusercontent.com/assets/98546/24312222/96f131d6-10fd-11e7-85b0-dd3b1c428a04.png)

Fixed response:

![high_res](https://cloud.githubusercontent.com/assets/98546/24312239/a074b3ea-10fd-11e7-803a-fe967334654c.png)