### PR TITLE
Require at least 1 character before _runtime

### DIFF
--- a/lib/rails_server_timings/controller_runtime.rb
+++ b/lib/rails_server_timings/controller_runtime.rb
@@ -7,7 +7,7 @@ module RailsServerTimings
         timings = []
 
         payload.each do |key, value|
-          if idx = key.to_s =~ /_runtime/
+          if idx = key.to_s =~ /\w+_runtime/
             timings << ("#{key[0, idx]}=%.3f" % value.to_f)
           end
         end

--- a/lib/rails_server_timings/controller_runtime.rb
+++ b/lib/rails_server_timings/controller_runtime.rb
@@ -7,7 +7,7 @@ module RailsServerTimings
         timings = []
 
         payload.each do |key, value|
-          if idx = key.to_s =~ /\w+_runtime/
+          if idx = key.to_s =~ /\w+_runtime$/
             timings << ("#{key[0, idx]}=%.3f" % value.to_f)
           end
         end


### PR DESCRIPTION
The regex `/_runtime/` will also match strings that start with `_runtime` which means `idx` would be `0` resulting in a bad value from `#{key[0, idx]}`.

This patch makes sure there is at least one character before `_runtime`.  Note that you might also want to put `$` at the end of the regex if you always want `_runtime` to be at the end of the string, else it also matches `_runtimefoobarbaz`