### PR TITLE
Fix missing stat names

### DIFF
--- a/lib/rails_server_timings/controller_runtime.rb
+++ b/lib/rails_server_timings/controller_runtime.rb
@@ -7,8 +7,8 @@ module RailsServerTimings
         timings = []
 
         payload.each do |key, value|
-          if idx = key.to_s =~ /\w+_runtime$/
-            timings << ("#{key[0, idx]}=%.3f" % value.to_f)
+          if key.to_s =~ /\w+_runtime$/
+            timings << ("#{key.to_s.chomp('_runtime')}=%.3f" % value.to_f)
           end
         end
 


### PR DESCRIPTION
These were accidentally broken by #4.

@PikachuEXE Can you test this and confirm it solves the problem you were seeing? You should be able to grab this git branch in your Gemfile with something like:
```ruby
gem 'rails_server_timings', :github => 'dpogue/rails_server_timings', :branch => 'runtime-fix'
```